### PR TITLE
TAC-3940 | Create service-specific server list classes.

### DIFF
--- a/src/Hosting/Server.php
+++ b/src/Hosting/Server.php
@@ -212,7 +212,7 @@ final class Server implements ServerInterface
      */
     public function setServices($services)
     {
-        if (!is_array($services) || empty($services)) {
+        if (!is_array($services)) {
             throw new \InvalidArgumentException(
                 sprintf('%s: $services expects an array.', __METHOD__)
             );

--- a/src/Hosting/Server/BalancerServerList.php
+++ b/src/Hosting/Server/BalancerServerList.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting\Server;
+
+use Acquia\Platform\Cloud\Hosting\ServerInterface;
+
+class BalancerServerList extends ServerList implements BalancerServerListInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * This implementation is based on data returned from Cloud API
+     */
+    public function getActiveBalancers()
+    {
+        $activeBalancers = new static;
+
+        /** @var ServerInterface $balancer */
+        foreach ($this as $balancer) {
+            $services = $balancer->getServices();
+            if (empty($services['varnish']) || empty($services['varnish']['status'])) {
+                continue;
+            }
+            if ($services['varnish']['status'] != 'active') {
+                continue;
+            }
+            $activeBalancers->append($balancer);
+        }
+
+        return $activeBalancers;
+    }
+}

--- a/src/Hosting/Server/BalancerServerListInterface.php
+++ b/src/Hosting/Server/BalancerServerListInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting\Server;
+
+interface BalancerServerListInterface extends ServerListInterface
+{
+    /**
+     * Return list of balancers that are currently active.
+     *
+     * @return BalancerServerListInterface
+     */
+    public function getActiveBalancers();
+}

--- a/src/Hosting/Server/DatabaseServerList.php
+++ b/src/Hosting/Server/DatabaseServerList.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting\Server;
+
+class DatabaseServerList extends ServerList implements DatabaseServerListInterface
+{
+
+}

--- a/src/Hosting/Server/DatabaseServerListInterface.php
+++ b/src/Hosting/Server/DatabaseServerListInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting\Server;
+
+interface DatabaseServerListInterface extends ServerListInterface
+{
+
+}

--- a/src/Hosting/Server/FileServerList.php
+++ b/src/Hosting/Server/FileServerList.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting\Server;
+
+class FileServerList extends ServerList implements FileServerListInterface
+{
+
+}

--- a/src/Hosting/Server/FileServerListInterface.php
+++ b/src/Hosting/Server/FileServerListInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting\Server;
+
+interface FileServerListInterface extends ServerListInterface
+{
+
+}

--- a/src/Hosting/Server/WebServerList.php
+++ b/src/Hosting/Server/WebServerList.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting\Server;
+
+class WebServerList extends ServerList implements WebServerListInterface
+{
+
+}

--- a/src/Hosting/Server/WebServerListInterface.php
+++ b/src/Hosting/Server/WebServerListInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting\Server;
+
+interface WebServerListInterface extends ServerListInterface
+{
+
+}

--- a/tests/Hosting/Server/BalancerServerListTest.php
+++ b/tests/Hosting/Server/BalancerServerListTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Tests\Hosting\Server;
+
+use Acquia\Platform\Cloud\Hosting\Server;
+use Acquia\Platform\Cloud\Hosting\Server\BalancerServerList;
+use Acquia\Platform\Cloud\Hosting\Server\BalancerServerListInterface;
+use Acquia\Platform\Cloud\Hosting\ServerInterface;
+
+/**
+ * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Server\BalancerServerList
+ */
+class BalancerServerListTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::getActiveBalancers
+     */
+    public function testgetActiveBalancers()
+    {
+        $serverList = new BalancerServerList();
+        $serverList->append(Server::create([
+            'name' => 'bal-123',
+            'services' => [
+                'varnish' => ['status' => 'active'],
+            ],
+        ]));
+        $serverList->append(Server::create([
+            'name' => 'bal-234',
+            'services' => [
+                'varnish' => ['status' => 'hot_spare'],
+            ],
+        ]));
+        $serverList->append(Server::create([
+            'name' => 'bal-345',
+            'services' => [],
+        ]));
+        $this->assertEquals(3, count($serverList));
+
+        /** @var BalancerServerListInterface $activeBals */
+        $activeBals = $serverList->getActiveBalancers();
+        $this->assertEquals(1, count($activeBals));
+
+        /** @var ServerInterface $activeBal */
+        $activeBal = $activeBals[0];
+        $this->assertEquals('bal-123', $activeBal->getName());
+    }
+}

--- a/tests/Hosting/ServerTest.php
+++ b/tests/Hosting/ServerTest.php
@@ -274,11 +274,11 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers ::setServices
-     * @expectedException \InvalidArgumentException
      */
-    public function testSetServicesWillThrowExceptionIfEmptyArray()
+    public function testSetServicesWillNotThrowExceptionIfEmptyArray()
     {
         $server = new Server('test');
         $server->setServices([]);
+        $this->assertEmpty($server->getServices());
     }
 }


### PR DESCRIPTION
We can reduce complexity in the Environment class by shifting some of its
responsibility to service-specific list classes. This PR adds the skeleton
for those classes, with an example BalancerServerList::getActiveBalancers()
method.

Additionally this PR fixes an issue with Server::setServices() to allow
services which are an empty array to be set (common in Cloud API data).
