### PR TITLE
TAC-3959 | EnvironmentList members should be accessible by name.

### DIFF
--- a/src/Hosting/Environment.php
+++ b/src/Hosting/Environment.php
@@ -308,4 +308,15 @@ final class Environment implements EnvironmentInterface
         }
         return $this->serverList;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getApplicationQualifiedName()
+    {
+        /*
+         * Considering data from Cloud API, Unix Username provides the same result.
+         */
+        return $this->getUnixUserName();
+    }
 }

--- a/src/Hosting/Environment/EnvironmentList.php
+++ b/src/Hosting/Environment/EnvironmentList.php
@@ -11,8 +11,31 @@
 
 namespace Acquia\Platform\Cloud\Hosting\Environment;
 
+use Acquia\Platform\Cloud\Hosting\EnvironmentInterface;
+
 class EnvironmentList extends \ArrayObject implements EnvironmentListInterface
 {
+    /**
+     * Implementation of ArrayAccess::offsetGet()
+     *
+     * Overrides ArrayObject::offsetGet() to allow using an Environment name as
+     * a key.
+     *
+     * @param mixed $index
+     *
+     * @return mixed|null
+     */
+    public function offsetGet($index)
+    {
+        if (is_numeric($index)) {
+            return parent::offsetGet($index);
+        }
+        if (strpos($index, '.') > 0) {
+            return $this->getEnvironmentByApplicationQualifiedName($index);
+        }
+        return $this->getEnvironmentByMachineName($index);
+    }
+    
     /**
      * Implementation of ArrayAccess::offsetSet()
      *
@@ -59,6 +82,35 @@ class EnvironmentList extends \ArrayObject implements EnvironmentListInterface
         }
 
         return $filteredList;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEnvironmentByMachineName($name)
+    {
+        $namedEnvironment = null;
+        foreach ($this as $environment) {
+            if ($environment->getMachineName() === $name) {
+                $namedEnvironment = $environment;
+            }
+        }
+        return $namedEnvironment;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEnvironmentByApplicationQualifiedName($name)
+    {
+        $namedEnvironment = null;
+        /** @var EnvironmentInterface $environment */
+        foreach ($this as $environment) {
+            if ($environment->getApplicationQualifiedName() === $name) {
+                $namedEnvironment = $environment;
+            }
+        }
+        return $namedEnvironment;
     }
 
     /**

--- a/src/Hosting/Environment/EnvironmentListInterface.php
+++ b/src/Hosting/Environment/EnvironmentListInterface.php
@@ -11,6 +11,8 @@
 
 namespace Acquia\Platform\Cloud\Hosting\Environment;
 
+use Acquia\Platform\Cloud\Hosting\EnvironmentInterface;
+
 interface EnvironmentListInterface
 {
     /**
@@ -21,6 +23,24 @@ interface EnvironmentListInterface
      * @return EnvironmentListInterface
      */
     public function filterByName($names);
+
+    /**
+     * Retrieves an environment object by its machine name.
+     *
+     * @param $name
+     *
+     * @return EnvironmentInterface
+     */
+    public function getEnvironmentByMachineName($name);
+
+    /**
+     * Retrieves an environment object by its application.environment name.
+     *
+     * @param $name
+     *
+     * @return EnvironmentInterface
+     */
+    public function getEnvironmentByApplicationQualifiedName($name);
 
     /**
      * Returns a simple array of environment names.

--- a/src/Hosting/EnvironmentInterface.php
+++ b/src/Hosting/EnvironmentInterface.php
@@ -144,4 +144,11 @@ interface EnvironmentInterface
      * @return ServerListInterface
      */
     public function getServerList();
+
+    /**
+     * Returns the application.environment name of the environment.
+     *
+     * @return string
+     */
+    public function getApplicationQualifiedName();
 }

--- a/tests/Hosting/Environment/EnvironmentListTest.php
+++ b/tests/Hosting/Environment/EnvironmentListTest.php
@@ -29,6 +29,7 @@ class EnvironmentListTest extends \PHPUnit_Framework_TestCase
         foreach ($childrenOfTitans as $titanName) {
             $env = new Environment($titanName);
             $env->setMachineName('myapp' . $titanName);
+            $env->setUnixUserName("myapp.{$titanName}");
             $environmentList->append($env);
         }
         return $environmentList;
@@ -115,11 +116,74 @@ class EnvironmentListTest extends \PHPUnit_Framework_TestCase
     public function testGetNames()
     {
         $environmentList = $this->getBasicEnvironmentList()->filterByName($this->childrenOfLeto);
-        ;
         $expected = [
             'Apollo' => 'myappApollo',
             'Artemis' => 'myappArtemis',
         ];
         $this->assertEquals($expected, $environmentList->getNames());
+    }
+
+    /**
+     * @covers ::getEnvironmentByMachineName
+     */
+    public function testGetEnvironmentByMachineName()
+    {
+        $environmentList = $this->getBasicEnvironmentList();
+        $this->assertEquals(
+            'Apollo',
+            $environmentList->getEnvironmentByMachineName('myappApollo')->getName()
+        );
+        $this->assertEquals(
+            'Artemis',
+            $environmentList->getEnvironmentByMachineName('myappArtemis')->getName()
+        );
+    }
+
+    /**
+     * @covers ::getEnvironmentByApplicationQualifiedName
+     */
+    public function testGetEnvironmentByApplicationQualifiedName()
+    {
+        $environmentList = $this->getBasicEnvironmentList();
+        $this->assertEquals(
+            'Apollo',
+            $environmentList->getEnvironmentByApplicationQualifiedName('myapp.Apollo')->getName()
+        );
+        $this->assertEquals(
+            'Artemis',
+            $environmentList->getEnvironmentByApplicationQualifiedName('myapp.Artemis')->getName()
+        );
+    }
+
+    /**
+     * @covers ::offsetGet
+     */
+    public function testCanAccessElementByEnvironmentNameOrIndex()
+    {
+        $environmentList = $this->getBasicEnvironmentList();
+        $this->assertEquals(
+            'Apollo',
+            $environmentList[0]->getName()
+        );
+        $this->assertEquals(
+            'Artemis',
+            $environmentList[1]->getName()
+        );
+        $this->assertEquals(
+            'Apollo',
+            $environmentList['myappApollo']->getName()
+        );
+        $this->assertEquals(
+            'Artemis',
+            $environmentList['myappArtemis']->getName()
+        );
+        $this->assertEquals(
+            'Apollo',
+            $environmentList['myapp.Apollo']->getName()
+        );
+        $this->assertEquals(
+            'Artemis',
+            $environmentList['myapp.Artemis']->getName()
+        );
     }
 }

--- a/tests/Hosting/EnvironmentTest.php
+++ b/tests/Hosting/EnvironmentTest.php
@@ -354,6 +354,23 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $environment->getServerList();
     }
 
+    /**
+     * @covers ::getApplicationQualifiedName
+     */
+    public function testCanReturnApplicationQualifiedName()
+    {
+        $environment = new Environment('test');
+        $users = [
+            'myapp.dev',
+            'myapp.test',
+            'myapp.prod',
+        ];
+        foreach ($users as $user) {
+            $environment->setUnixUserName($user);
+            $this->assertEquals($user, $environment->getApplicationQualifiedName());
+        }
+    }
+
     public function commonDataProvider()
     {
         return array(


### PR DESCRIPTION
allows:

```
$env1 = $envList['app.env'];
$env2 = $envList['appenv'];
```
