### PR TITLE
TAC-4143 | acquia-platform-cloud-data-model needs a DbBackup class.

### DIFF
--- a/src/Hosting/DbBackup.php
+++ b/src/Hosting/DbBackup.php
@@ -1,0 +1,317 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting;
+
+final class DbBackup implements DbBackupInterface
+{
+    /**
+     * @var int
+     */
+    private $backupId;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $link;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var int
+     */
+    private $started;
+
+    /**
+     * @var int
+     */
+    private $completed;
+
+    /**
+     * @var bool
+     */
+    private $deleted;
+
+    /**
+     * @var string
+     */
+    private $checksum;
+
+    public function __construct($backupId)
+    {
+        if (!is_int($backupId)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    '%s: DbBackup ID must be an alphanumeric int (%s given)',
+                    __METHOD__,
+                    is_int($backupId) ? $backupId : gettype($backupId)
+                )
+            );
+        }
+        $this->backupId = $backupId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function create(array $dbBackupData)
+    {
+        $app = new static($dbBackupData['id']);
+
+        $propertySetters = [
+            'type' => 'setType',
+            'name' => 'setName',
+            'link' => 'setLink',
+            'path' => 'setPath',
+            'started' => 'setStarted',
+            'completed' => 'setCompleted',
+            'deleted' => 'setDeleted',
+            'checksum' => 'setChecksum',
+        ];
+
+        foreach ($propertySetters as $property => $setter) {
+            if (isset($dbBackupData[$property]) && method_exists($app, $setter)) {
+                call_user_func([$app, $setter], $dbBackupData[$property]);
+            }
+        }
+
+        return $app;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->backupId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        if ($this->type === null) {
+            throw new \RuntimeException(
+                sprintf('%s: This DbBackup object does not know the type.', __METHOD__)
+            );
+        }
+        return $this->type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setType($type)
+    {
+        if (!is_string($type) || empty($type)) {
+            throw new \InvalidArgumentException(
+                sprintf('%s: $type expects a string.', __METHOD__)
+            );
+        }
+        $this->type = $type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        if ($this->name === null) {
+            throw new \RuntimeException(
+                sprintf('%s: This DbBackup object does not know the name.', __METHOD__)
+            );
+        }
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setName($name)
+    {
+        if (!is_string($name) || empty($name)) {
+            throw new \InvalidArgumentException(
+                sprintf('%s: $name expects a string.', __METHOD__)
+            );
+        }
+        $this->name = $name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLink()
+    {
+        if ($this->link === null) {
+            throw new \RuntimeException(
+                sprintf('%s: This DbBackup object does not know the link.', __METHOD__)
+            );
+        }
+        return $this->link;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLink($link)
+    {
+        if (!is_string($link) || empty($link)) {
+            throw new \InvalidArgumentException(
+                sprintf('%s: $link expects an string.', __METHOD__)
+            );
+        }
+        $this->link = $link;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        if ($this->path === null) {
+            throw new \RuntimeException(
+                sprintf('%s: This DbBackup object does not know the path.', __METHOD__)
+            );
+        }
+        return $this->path;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPath($path)
+    {
+        if (!is_string($path) || empty($path)) {
+            throw new \InvalidArgumentException(
+                sprintf('%s: $path expects a string.', __METHOD__)
+            );
+        }
+        $this->path = $path;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStarted()
+    {
+        if ($this->started === null) {
+            throw new \RuntimeException(
+                sprintf('%s: This DbBackup object does not know the started time.', __METHOD__)
+            );
+        }
+        return $this->started;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStarted($started)
+    {
+        if (!is_int($started) || empty($started)) {
+            throw new \InvalidArgumentException(
+                sprintf('%s: $started expects an int.', __METHOD__)
+            );
+        }
+        $this->started = $started;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCompleted()
+    {
+        if ($this->completed === null) {
+            throw new \RuntimeException(
+                sprintf('%s: This DbBackup object does not know the completed time.', __METHOD__)
+            );
+        }
+        return $this->completed;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCompleted($completed)
+    {
+        if (!is_int($completed) || empty($completed)) {
+            throw new \InvalidArgumentException(
+                sprintf('%s: $completed expects an int.', __METHOD__)
+            );
+        }
+        $this->completed = $completed;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDeleted()
+    {
+        if ($this->deleted === null) {
+            throw new \RuntimeException(
+                sprintf('%s: This DbBackup object does not know the deleted status.', __METHOD__)
+            );
+        }
+        return $this->deleted;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDeleted($deleted)
+    {
+        if (!is_int($deleted) || !($deleted == 0 || $deleted == 1)) {
+            throw new \InvalidArgumentException(
+                sprintf('%s: $deleted expects an int of value 0 or 1.', __METHOD__)
+            );
+        }
+        $this->deleted = $deleted;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChecksum()
+    {
+        if ($this->checksum === null) {
+            throw new \RuntimeException(
+                sprintf('%s: This DbBackup object does not know the checksum.', __METHOD__)
+            );
+        }
+        return $this->checksum;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setChecksum($checksum)
+    {
+        if (!is_string($checksum) || empty($checksum)) {
+            throw new \InvalidArgumentException(
+                sprintf('%s: $checksum expects a string.', __METHOD__)
+            );
+        }
+        $this->checksum = $checksum;
+    }
+}

--- a/src/Hosting/DbBackup/DbBackupDecoratorMethods.php
+++ b/src/Hosting/DbBackup/DbBackupDecoratorMethods.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting\DbBackup;
+
+use Acquia\Platform\Cloud\Hosting\DbBackupInterface;
+
+trait DbBackupDecoratorMethods
+{
+    /**
+     * @var DbBackupInterface
+     */
+    protected $dbBackup;
+
+    /**
+     * Returns the decorated dbBackup instance.
+     *
+     * @return DbBackupInterface the decorated DbBackup
+     */
+    public function getDbBackup()
+    {
+        return $this->dbBackup;
+    }
+
+    /**
+     * Sets the dbBackup instance being decorated.
+     *
+     * @param DbBackupInterface $dbBackup the DbBackup to decorate
+     */
+    public function setDbBackup(DbBackupInterface $dbBackup)
+    {
+        $this->dbBackup = $dbBackup;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->dbBackup->getId();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return $this->dbBackup->getType();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setType($name)
+    {
+        $this->dbBackup->setType($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->dbBackup->getName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setName($name)
+    {
+        $this->dbBackup->setName($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLink()
+    {
+        return $this->dbBackup->getLink();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLink($link)
+    {
+        $this->dbBackup->setLink($link);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        return $this->dbBackup->getPath();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPath($path)
+    {
+        $this->dbBackup->setPath($path);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStarted()
+    {
+        return $this->dbBackup->getStarted();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStarted($started)
+    {
+        $this->dbBackup->setStarted($started);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCompleted()
+    {
+        return $this->dbBackup->getCompleted();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCompleted($completed)
+    {
+        $this->dbBackup->setCompleted($completed);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDeleted()
+    {
+        return $this->dbBackup->getDeleted();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDeleted($deleted)
+    {
+        $this->dbBackup->setDeleted($deleted);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChecksum()
+    {
+        return $this->dbBackup->getChecksum();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setChecksum($checksum)
+    {
+        $this->dbBackup->setChecksum($checksum);
+    }
+}

--- a/src/Hosting/DbBackupInterface.php
+++ b/src/Hosting/DbBackupInterface.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting;
+
+/**
+ * A DbBackup corresponds to a backup of a database for a client's application.
+ * It contains:
+ * - A backup ID eg. 12345678
+ * - A backup type, eg. daily, or ondemand
+ * - A name, eg. mysite
+ * - A link, eg. https://www.acquia.com/
+ * - A path, eg. backups/user-prod-db-backup.sql.gz
+ * - A started timestamp, eg. 1468218381
+ * - A completed timestamp, eg. 1468219381
+ * - A deleted marker, eg. 0 or 1
+ * - A checksum, eg. a9e3dac5c312f49415b613aff078f5dd
+ */
+interface DbBackupInterface
+{
+    /**
+     * Factory method for DbBackup classes.
+     *
+     * @param array $dbBackupData
+     *
+     * @return DbBackupInterface
+     */
+    public static function create(array $dbBackupData);
+
+    /**
+     * Returns the ID of the dbbackup.
+     *
+     * @return int The ID of the dbbackup.
+     */
+    public function getId();
+
+    /**
+     * Returns the type of the database backup.
+     *
+     * @return string The type of the database backup.
+     */
+    public function getType();
+    
+    /**
+     * Sets the type of the dbbackup.
+     *
+     * @param string $type The type of the dbbackup.
+     */
+    public function setType($type);
+
+    /**
+     * Returns the name for the database backup.
+     *
+     * @return int The name for the database backup.
+     */
+    public function getName();
+    
+    /**
+     * Sets the name of the dbbackup.
+     *
+     * @param int $siteId The name of the dbbackup.
+     */
+    public function setName($siteId);
+
+    /**
+     * Returns the Link for the database backup.
+     *
+     * @return int The Link for the database backup.
+     */
+    public function getLink();
+    
+    /**
+     * Sets the Link of the dbbackup.
+     *
+     * @param int $dbId The Link of the dbbackup.
+     */
+    public function setLink($dbId);
+
+    /**
+     * Returns the path for the database backup.
+     *
+     * @return string The path for the database backup.
+     */
+    public function getPath();
+    
+    /**
+     * Sets the path of the dbbackup.
+     *
+     * @param string $path The path of the dbbackup.
+     */
+    public function setPath($path);
+
+    /**
+     * Returns the started timestamp for the database backup.
+     *
+     * @return int The started timestamp for the database backup.
+     */
+    public function getStarted();
+    
+    /**
+     * Sets the started timestamp of the dbbackup.
+     *
+     * @param int $started The started timestamp of the dbbackup.
+     */
+    public function setStarted($started);
+
+    /**
+     * Returns the completed timestamp for the database backup.
+     *
+     * @return int The completed timestamp for the database backup.
+     */
+    public function getCompleted();
+    
+    /**
+     * Sets the completed timestamp of the dbbackup.
+     *
+     * @param int $completed The completed timestamp of the dbbackup.
+     */
+    public function setCompleted($completed);
+
+    /**
+     * Returns whether or not the database backup has been deleted.
+     *
+     * @return int whether or not the database backup has been deleted.
+     */
+    public function getDeleted();
+    
+    /**
+     * Sets the deleted value of the dbbackup.
+     *
+     * @param int $deleted The deleted value of the dbbackup.
+     */
+    public function setDeleted($deleted);
+
+    /**
+     * Returns the checksum for the database backup.
+     *
+     * @return string The checksum for the database backup.
+     */
+    public function getChecksum();
+    
+    /**
+     * Sets the checksum of the dbbackup.
+     *
+     * @param string $checksum The checksum of the dbbackup.
+     */
+    public function setChecksum($checksum);
+}

--- a/tests/Hosting/DbBackup/DbBackupDecoratorMethodsTest.php
+++ b/tests/Hosting/DbBackup/DbBackupDecoratorMethodsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Tests\Hosting\DbBackup;
+
+use Acquia\Platform\Cloud\Hosting\DbBackup\DbBackupDecoratorMethods;
+use Acquia\Platform\Cloud\Hosting\DbBackupInterface;
+
+/**
+ * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\DbBackup\DbBackupDecoratorMethods
+ */
+class DbBackupDecoratorMethodsTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_TRAIT = 'Acquia\Platform\Cloud\Hosting\DbBackup\DbBackupDecoratorMethods';
+    const TEST_CLASS = 'Acquia\Platform\Cloud\Hosting\DbBackupInterface';
+
+    /**
+     * @covers ::getDbBackup
+     * @covers ::setDbBackup
+     */
+    public function testDbBackupDecoratorMethodsMaySetDecoratedDbBackup()
+    {
+        /** @var DbBackupDecoratorMethods $mockTrait */
+        $mockTrait = $this->getMockForTrait(self::TEST_TRAIT);
+        /** @var DbBackupInterface $mockClass   */
+        $mockClass = $this->getMockBuilder(self::TEST_CLASS)->getMock();
+
+        $mockTrait->setDbBackup($mockClass);
+        $this->assertEquals($mockClass, $mockTrait->getDbBackup());
+    }
+
+    /**
+     * @covers ::getId
+     * @covers ::getType
+     * @covers ::getName
+     * @covers ::getLink
+     * @covers ::getPath
+     * @covers ::getStarted
+     * @covers ::getCompleted
+     * @covers ::getDeleted
+     * @covers ::getChecksum
+     * @dataProvider getDbBackupInterfaceGetters
+     */
+    public function testDbBackupDecoratorMethodsPassesGettersToDbBackup($getter, $expected)
+    {
+        /** @var DbBackupDecoratorMethods $mockTrait */
+        $mockTrait = $this->getMockForTrait(self::TEST_TRAIT);
+        $mockClass = $this->getMockBuilder(self::TEST_CLASS)
+            ->getMock();
+        $mockClass->expects($this->once())
+            ->method($getter)
+            ->willReturn($expected);
+
+        $mockTrait->setDbBackup($mockClass);
+        $this->assertEquals($expected, call_user_func([$mockTrait, $getter]));
+    }
+
+    /**
+     * @covers ::setType
+     * @covers ::setName
+     * @covers ::setLink
+     * @covers ::setPath
+     * @covers ::setStarted
+     * @covers ::setCompleted
+     * @covers ::setDeleted
+     * @covers ::setChecksum
+     * @dataProvider getDbBackupInterfaceSetters
+     */
+    public function testDbBackupDecoratorMethodsPassesSettersToDbBackup($setter, $expected)
+    {
+        /** @var DbBackupDecoratorMethods $mockTrait */
+        $mockTrait = $this->getMockForTrait(self::TEST_TRAIT);
+        $mockClass = $this->getMockBuilder(self::TEST_CLASS)
+            ->getMock();
+        $mockClass->expects($this->once())
+            ->method($setter)
+            ->with($expected);
+
+        $mockTrait->setDbBackup($mockClass);
+        call_user_func([$mockTrait, $setter], $expected);
+    }
+
+    public function getDbBackupInterfaceGetters()
+    {
+        return [
+            ['getId', 12345678],
+            ['getType', 'daily'],
+            ['getName', 'mysite'],
+            ['getLink', 'http://www.acquia.com/'],
+            ['getPath', 'backups/user-prod-db-backup.sql.gz'],
+            ['getStarted', 1468218381],
+            ['getCompleted', 1468219381],
+            ['getDeleted', 0],
+            ['getChecksum', 'a9e3dac5c312f49415b613aff078f5dd'],
+        ];
+    }
+
+    public function getDbBackupInterfaceSetters()
+    {
+        return [
+            ['setType', 'daily'],
+            ['setName', 'mysite'],
+            ['setLink', 'http://www.acquia.com/'],
+            ['setPath', 'backups/user-prod-db-backup.sql.gz'],
+            ['setStarted', 1468218381],
+            ['setCompleted', 1468219381],
+            ['setDeleted', 0],
+            ['setChecksum', 'a9e3dac5c312f49415b613aff078f5dd'],
+        ];
+    }
+}

--- a/tests/Hosting/DbBackupTest.php
+++ b/tests/Hosting/DbBackupTest.php
@@ -1,0 +1,361 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Tests\Hosting;
+
+use Acquia\Platform\Cloud\Hosting\DbBackup;
+
+/**
+ * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\DbBackup
+ */
+class DbBackupTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::getId
+     */
+    public function testIdPropertyMayBeAccessedViaMethods()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $this->assertEquals(12345678, $dbBackup->getId());
+    }
+
+    /**
+     * @covers ::__construct
+     * @expectedException \InvalidArgumentException
+     */
+    public function testIdPropertyMustBeAnInt()
+    {
+        $dbBackup = new DbBackup([]);
+    }
+
+    /**
+     * @covers ::create()
+     */
+    public function testDbBackupCanBeInstantiatedWithFactoryMethod()
+    {
+        $dbBackup = DbBackup::create(['id' => 12345678]);
+        $this->assertInstanceOf('\Acquia\Platform\Cloud\Hosting\DbBackup', $dbBackup);
+        $this->assertInstanceOf('\Acquia\Platform\Cloud\Hosting\DbBackupInterface', $dbBackup);
+
+        $dbBackup = DbBackup::create(
+            [
+                'id' => 12345678,
+                'type' => 'daily',
+                'name' => 'sitename',
+                'link' => 'https://www.acquia.com/',
+                'path' => 'backups/user-prod-db-backup.sql.gz',
+                'started' => 1468218381,
+                'completed' => 1468219381,
+                'deleted' => 0,
+                'checksum' => 'a9e3dac5c312f49415b613aff078f5dd',
+            ]
+        );
+        $this->assertInstanceOf('\Acquia\Platform\Cloud\Hosting\DbBackup', $dbBackup);
+        $this->assertInstanceOf('\Acquia\Platform\Cloud\Hosting\DbBackupInterface', $dbBackup);
+    }
+
+    /**
+     * @covers ::getType
+     * @covers ::setType
+     */
+    public function testTypePropertyMayBeAccessedViaMethods()
+    {
+        $type = 'daily';
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setType($type);
+        $this->assertEquals($type, $dbBackup->getType());
+    }
+
+    /**
+     * @covers ::getType
+     * @expectedException \RuntimeException
+     */
+    public function testGetTypeWillThrowExceptionIfPropertyNotSet()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->getType();
+    }
+
+    /**
+     * @covers ::setType
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetTypeWillThrowExceptionIfNotAString()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setType([]);
+    }
+
+    /**
+     * @covers ::setType
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetTypeWillThrowExceptionIfEmptyString()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setType('');
+    }
+
+    /**
+     * @covers ::getName
+     * @covers ::setName
+     */
+    public function testNamePropertyMayBeAccessedViaMethods()
+    {
+        $name = 'sitename';
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setName($name);
+        $this->assertEquals($name, $dbBackup->getName());
+    }
+
+    /**
+     * @covers ::getName
+     * @expectedException \RuntimeException
+     */
+    public function testGetNameWillThrowExceptionIfPropertyNotSet()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->getName();
+    }
+
+    /**
+     * @covers ::setName
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetNameWillThrowExceptionIfNotAString()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setName([]);
+    }
+
+    /**
+     * @covers ::getLink
+     * @covers ::setLink
+     */
+    public function testLinkPropertyMayBeAccessedViaMethods()
+    {
+        $link = 'http://www.acquia.com/';
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setLink($link);
+        $this->assertEquals($link, $dbBackup->getLink());
+    }
+
+    /**
+     * @covers ::getLink
+     * @expectedException \RuntimeException
+     */
+    public function testGetLinkWillThrowExceptionIfPropertyNotSet()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->getLink();
+    }
+
+    /**
+     * @covers ::setLink
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetLinkWillThrowExceptionIfNotAString()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setLink([]);
+    }
+
+    /**
+     * @covers ::getPath
+     * @covers ::setPath
+     */
+    public function testPathPropertyMayBeAccessedViaMethods()
+    {
+        $path = 'backups/user-prod-db-backup.sql.gz';
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setPath($path);
+        $this->assertEquals($path, $dbBackup->getPath());
+    }
+
+    /**
+     * @covers ::getPath
+     * @expectedException \RuntimeException
+     */
+    public function testGetPathWillThrowExceptionIfPropertyNotSet()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->getPath();
+    }
+
+    /**
+     * @covers ::setPath
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetPathWillThrowExceptionIfNotAString()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setPath([]);
+    }
+
+    /**
+     * @covers ::setPath
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetPathWillThrowExceptionIfEmptyString()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setPath('');
+    }
+
+    /**
+     * @covers ::getStarted
+     * @covers ::setStarted
+     */
+    public function testStartedPropertyMayBeAccessedViaMethods()
+    {
+        $started = 1468218381;
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setStarted($started);
+        $this->assertEquals($started, $dbBackup->getStarted());
+    }
+
+    /**
+     * @covers ::getStarted
+     * @expectedException \RuntimeException
+     */
+    public function testGetStartedWillThrowExceptionIfPropertyNotSet()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->getStarted();
+    }
+
+    /**
+     * @covers ::setStarted
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetStartedWillThrowExceptionIfNotAnInt()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setStarted([]);
+    }
+
+    /**
+     * @covers ::getCompleted
+     * @covers ::setCompleted
+     */
+    public function testCompletedPropertyMayBeAccessedViaMethods()
+    {
+        $completed = 1468219381;
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setCompleted($completed);
+        $this->assertEquals($completed, $dbBackup->getCompleted());
+    }
+
+    /**
+     * @covers ::getCompleted
+     * @expectedException \RuntimeException
+     */
+    public function testGetCompletedWillThrowExceptionIfPropertyNotSet()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->getCompleted();
+    }
+
+    /**
+     * @covers ::setCompleted
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetCompletedWillThrowExceptionIfNotAnInt()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setCompleted([]);
+    }
+
+    /**
+     * @covers ::getDeleted
+     * @covers ::setDeleted
+     */
+    public function testDeletedPropertyMayBeAccessedViaMethods()
+    {
+        $deleted = 0;
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setDeleted($deleted);
+        $this->assertEquals($deleted, $dbBackup->getDeleted());
+    }
+
+    /**
+     * @covers ::getDeleted
+     * @expectedException \RuntimeException
+     */
+    public function testGetDeletedWillThrowExceptionIfPropertyNotSet()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->getDeleted();
+    }
+
+    /**
+     * @covers ::setDeleted
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetDeletedWillThrowExceptionIfNotAnInt()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setDeleted([]);
+    }
+
+    /**
+     * @covers ::setDeleted
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetDeletedWillThrowExceptionIfNotZeroOrOne()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setDeleted(5);
+    }
+
+    /**
+     * @covers ::getChecksum
+     * @covers ::setChecksum
+     */
+    public function testChecksumPropertyMayBeAccessedViaMethods()
+    {
+        $checksum = 'a9e3dac5c312f49415b613aff078f5dd';
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setChecksum($checksum);
+        $this->assertEquals($checksum, $dbBackup->getChecksum());
+    }
+
+    /**
+     * @covers ::getChecksum
+     * @expectedException \RuntimeException
+     */
+    public function testGetChecksumWillThrowExceptionIfPropertyNotSet()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->getChecksum();
+    }
+
+    /**
+     * @covers ::setChecksum
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetChecksumWillThrowExceptionIfNotAString()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setChecksum([]);
+    }
+
+    /**
+     * @covers ::setChecksum
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetChecksumWillThrowExceptionIfEmptyString()
+    {
+        $dbBackup = new DbBackup(12345678);
+        $dbBackup->setChecksum('');
+    }
+}


### PR DESCRIPTION
This commit adds `DbBackupInterface.php`, `DbBackup.php` & `DbBackupDecoratorMethods.php`, along with associated unit tests to the Cloud Platform Data Model. 

These classes and the methods within them take after the example of `DbInstance`.
