### PR TITLE
TAC-4144 | Acquia-platform-cloud-data-model needs a DbBackupList class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build
 /composer.lock
 /vendor
+*.DS_Store
+*.idea

--- a/src/Hosting/DbBackup/DbBackupList.php
+++ b/src/Hosting/DbBackup/DbBackupList.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting\DbBackup;
+
+use Acquia\Platform\Cloud\Hosting\DbBackupInterface;
+
+class DbBackupList extends \ArrayObject implements DbBackupListInterface
+{
+    /**
+     * Implementation of ArrayAccess::offsetSet()
+     *
+     * Overrides ArrayObject::offsetSet() to validate that the value set at the
+     * specified offset is a DbBackup.
+     *
+     * No value is returned.
+     *
+     * @param mixed             $offset
+     * @param DbBackupInterface $value
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (!is_subclass_of($value, 'Acquia\Platform\Cloud\Hosting\DbBackupInterface')) {
+            throw new \InvalidArgumentException(
+                sprintf('%s: $value must be an implementation of DbBackupInterface', __METHOD__)
+            );
+        }
+        parent::offsetSet($offset, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterById($backupIds)
+    {
+        if (!is_array($backupIds)) {
+            throw new \InvalidArgumentException(
+                sprintf('%s: $backupIds must be an array', __METHOD__)
+            );
+        }
+
+        $dbBackupSubset = new static();
+        $listIterator = $this->getIterator();
+        while ($listIterator->valid()) {
+            if (in_array($listIterator->current()->getId(), $backupIds)) {
+                $dbBackupSubset->append($listIterator->current());
+            }
+            $listIterator->next();
+        }
+
+        return $dbBackupSubset;
+    }
+}

--- a/src/Hosting/DbBackup/DbBackupListInterface.php
+++ b/src/Hosting/DbBackup/DbBackupListInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting\DbBackup;
+
+interface DbBackupListInterface
+{
+    /**
+     * Returns a subset of known database backups matching the provided backup ids
+     *
+     * @param array|int $backupIds An array of db backup ids.
+     *
+     * @return DbBackupListInterface
+     */
+    public function filterById($backupIds);
+}

--- a/tests/Hosting/DbBackup/DbBackupListTest.php
+++ b/tests/Hosting/DbBackup/DbBackupListTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Acquia Platform: Cloud Data Model.
+ *
+ * (c) Acquia, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acquia\Platform\Cloud\Tests\Hosting\DbBackup;
+
+use Acquia\Platform\Cloud\Hosting\DbBackup;
+use Acquia\Platform\Cloud\Hosting\DbBackup\DbBackupList;
+
+/**
+ * @coversDefaultClass Acquia\Platform\Cloud\Hosting\DbBackup\DbBackupList
+ */
+class DbBackupListTest extends \PHPUnit_Framework_TestCase
+{
+    private $primesUnderTen = [2, 3, 5, 7];
+    private $primesUnderTwenty = [11, 13, 17, 19];
+    private $primesUnderThirty = [23, 29];
+    private $primesUnderForty = [31, 37];
+    private $primesUnderFifty = [41, 43, 47];
+
+    protected function getBasicDbBackupList()
+    {
+        $dbBackupList = new DbBackupList();
+        $bunchOfPrimes = array_merge(
+            $this->primesUnderTen,
+            $this->primesUnderTwenty,
+            $this->primesUnderThirty,
+            $this->primesUnderForty,
+            $this->primesUnderFifty
+        );
+        foreach ($bunchOfPrimes as $prime) {
+            $dbBackupList->append(new DbBackup($prime));
+        }
+        return $dbBackupList;
+    }
+
+    /**
+     * @covers ::filterById()
+     */
+    public function testDbBackupListCanReturnAFilteredListOfContents()
+    {
+        $dbBackupList = $this->getBasicDbBackupList();
+        $this->assertEquals(15, $dbBackupList->count());
+
+        // filter by array
+        $primesUnderTen = $dbBackupList->filterById($this->primesUnderTen);
+        $this->assertInstanceOf('Acquia\Platform\Cloud\Hosting\DbBackup\DbBackupList', $primesUnderTen);
+        $this->assertEquals(4, $primesUnderTen->count());
+        $iterator = $primesUnderTen->getIterator();
+        while ($iterator->valid()) {
+            /* @var \Acquia\Platform\Cloud\Hosting\DbBackup $dbBackup */
+            $dbBackup = $iterator->current();
+            $this->assertInstanceOf('Acquia\Platform\Cloud\Hosting\DbBackup', $dbBackup);
+            $this->assertTrue(in_array($dbBackup->getId(), $this->primesUnderTen));
+            $this->assertFalse(in_array($dbBackup->getId(), $this->primesUnderTwenty));
+            $iterator->next();
+        }
+    }
+
+    /**
+     * @covers ::filterById
+     * @expectedException \InvalidArgumentException
+     * @dataProvider exceptionalFilterProvider()
+     */
+    public function testFilterWillThrowExceptionForBadParameter($filter)
+    {
+        $dbBackupList = $this->getBasicDbBackupList();
+        $dbBackupList->filterById($filter);
+    }
+
+    public function exceptionalFilterProvider()
+    {
+        return [
+            'null' => [null],
+            'stdClass' => [new \stdClass()],
+        ];
+    }
+
+    /**
+     * @covers ::offsetSet
+     * @expectedException \InvalidArgumentException
+     * @dataProvider exceptionalValueProvider()
+     */
+    public function testOffsetSetWillThrowExceptionForNonDbBackup($value)
+    {
+        $dbBackupList = $this->getBasicDbBackupList();
+        $dbBackupList->offsetSet(0, $value);
+    }
+
+    public function exceptionalValueProvider()
+    {
+        return [
+            'null' => [null],
+            'stdClass' => [new \stdClass()],
+        ];
+    }
+}


### PR DESCRIPTION
Implemented `DbBackupList` based off of `DbInstanceList`, along with associated unit tests. 

One particular difference of note is that `DbBackupList` filters by _backup ID_ rather than by server name. A `filterByName` method could easily be added if we want to, but since ID's are the only thing 100% guaranteed to always be present by the `DbBackupInterface`, it seemed like a better place to start. 

I also updated the .gitignore to ignore `*.DS_Store` and `*.idea` files.
