### PR TITLE
TAC-4249 | aht task:list should not throw an exception for tasks without "started".

### DIFF
--- a/src/Hosting/Task.php
+++ b/src/Hosting/Task.php
@@ -228,11 +228,6 @@ final class Task implements TaskInterface
      */
     public function getStarted()
     {
-        if ($this->started === null) {
-            throw new \RuntimeException(
-                sprintf('%s: This Task object has no started date.', __METHOD__)
-            );
-        }
         return $this->started;
     }
 
@@ -241,9 +236,9 @@ final class Task implements TaskInterface
      */
     public function setStarted($started)
     {
-        if (!is_numeric($started) || empty($started)) {
+        if (!is_numeric($started) && !is_null($started)) {
             throw new \InvalidArgumentException(
-                sprintf('%s: $started expects an integer.', __METHOD__)
+                sprintf('%s: $started expects an integer or null value.', __METHOD__)
             );
         }
         $this->started = $started;
@@ -275,11 +270,6 @@ final class Task implements TaskInterface
      */
     public function getSender()
     {
-        if ($this->sender === null) {
-            throw new \RuntimeException(
-                sprintf('%s: This Task object does not know sender.', __METHOD__)
-            );
-        }
         return $this->sender;
     }
 
@@ -288,9 +278,9 @@ final class Task implements TaskInterface
      */
     public function setSender($sender)
     {
-        if (!is_string($sender) || empty($sender)) {
+        if (!is_string($sender)) {
             throw new \InvalidArgumentException(
-                sprintf('%s: $sender expects an integer.', __METHOD__)
+                sprintf('%s: $sender expects a string.', __METHOD__)
             );
         }
         $this->sender = $sender;

--- a/src/Hosting/TaskInterface.php
+++ b/src/Hosting/TaskInterface.php
@@ -107,14 +107,14 @@ interface TaskInterface
     /**
      * Returns the UNIX timestamp of when the task was started.
      *
-     * @return int UNIX Timestamp when the task was started.
+     * @return int|null UNIX Timestamp when the task was started.
      */
     public function getStarted();
 
     /**
      * Sets the UNIX timestamp for when the task was started.
      *
-     * @param int $started UNIX timestamp when the task was started.
+     * @param int|null $started UNIX timestamp when the task was started.
      */
     public function setStarted($started);
 

--- a/tests/Hosting/TaskTest.php
+++ b/tests/Hosting/TaskTest.php
@@ -237,16 +237,6 @@ class TaskTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::getStarted
-     * @expectedException \RuntimeException
-     */
-    public function testGetStartedWillThrowExceptionIfPropertyNotSet()
-    {
-        $task = new Task(1234);
-        $task->getStarted();
-    }
-
-    /**
      * @covers ::setStarted
      * @expectedException \InvalidArgumentException
      */
@@ -300,16 +290,6 @@ class TaskTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::getSender
-     * @expectedException \RuntimeException
-     */
-    public function testGetSenderWillThrowExceptionIfPropertyNotSet()
-    {
-        $task = new Task(1234);
-        $task->getSender();
-    }
-
-    /**
      * @covers ::setSender
      * @expectedException \InvalidArgumentException
      */
@@ -317,16 +297,6 @@ class TaskTest extends \PHPUnit_Framework_TestCase
     {
         $task = new Task(1234);
         $task->setSender([]);
-    }
-
-    /**
-     * @covers ::setSender
-     * @expectedException \InvalidArgumentException
-     */
-    public function testSetSenderWillThrowExceptionIfEmptyString()
-    {
-        $task = new Task(1234);
-        $task->setSender('');
     }
 
     /**


### PR DESCRIPTION
- started field can be null if the task has not yet started.
- sender field can be null in some instances, specifically when task belongs to the 'server-relaunch' queue.
