### PR TITLE
TAC-4323 | DbBackup::create fails when db backup path is empty.

### DIFF
--- a/src/Hosting/DbBackup.php
+++ b/src/Hosting/DbBackup.php
@@ -190,11 +190,6 @@ final class DbBackup implements DbBackupInterface
      */
     public function getPath()
     {
-        if ($this->path === null) {
-            throw new \RuntimeException(
-                sprintf('%s: This DbBackup object does not know the path.', __METHOD__)
-            );
-        }
         return $this->path;
     }
 
@@ -203,9 +198,9 @@ final class DbBackup implements DbBackupInterface
      */
     public function setPath($path)
     {
-        if (!is_string($path) || empty($path)) {
+        if (!is_string($path) && !is_null($path)) {
             throw new \InvalidArgumentException(
-                sprintf('%s: $path expects a string.', __METHOD__)
+                sprintf('%s: $path expects a string or null value.', __METHOD__)
             );
         }
         $this->path = $path;
@@ -255,7 +250,7 @@ final class DbBackup implements DbBackupInterface
      */
     public function setCompleted($completed)
     {
-        if (!is_numeric($completed) || empty($completed)) {
+        if (!is_numeric($completed) || is_null($completed)) {
             throw new \InvalidArgumentException(
                 sprintf('%s: $completed expects an int.', __METHOD__)
             );
@@ -307,7 +302,7 @@ final class DbBackup implements DbBackupInterface
      */
     public function setChecksum($checksum)
     {
-        if (!is_string($checksum) || empty($checksum)) {
+        if (!is_string($checksum) || is_null($checksum)) {
             throw new \InvalidArgumentException(
                 sprintf('%s: $checksum expects a string.', __METHOD__)
             );

--- a/src/Hosting/DbBackupInterface.php
+++ b/src/Hosting/DbBackupInterface.php
@@ -87,14 +87,14 @@ interface DbBackupInterface
     /**
      * Returns the path for the database backup.
      *
-     * @return string The path for the database backup.
+     * @return string|null The path for the database backup.
      */
     public function getPath();
     
     /**
      * Sets the path of the dbbackup.
      *
-     * @param string $path The path of the dbbackup.
+     * @param string|null $path The path of the dbbackup.
      */
     public function setPath($path);
 

--- a/tests/Hosting/DbBackupTest.php
+++ b/tests/Hosting/DbBackupTest.php
@@ -182,33 +182,24 @@ class DbBackupTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::getPath
-     * @expectedException \RuntimeException
-     */
-    public function testGetPathWillThrowExceptionIfPropertyNotSet()
-    {
-        $dbBackup = new DbBackup(12345678);
-        $dbBackup->getPath();
-    }
-
-    /**
      * @covers ::setPath
      * @expectedException \InvalidArgumentException
      */
-    public function testSetPathWillThrowExceptionIfNotAString()
+    public function testSetPathWillThrowExceptionIfNotStringOrNull()
     {
         $dbBackup = new DbBackup(12345678);
         $dbBackup->setPath([]);
     }
 
     /**
+     * @covers ::getPath
      * @covers ::setPath
-     * @expectedException \InvalidArgumentException
      */
-    public function testSetPathWillThrowExceptionIfEmptyString()
+    public function testPathPropertyCanBeEmptyString()
     {
         $dbBackup = new DbBackup(12345678);
         $dbBackup->setPath('');
+        $this->assertEquals('', $dbBackup->getPath());
     }
 
     /**
@@ -353,9 +344,9 @@ class DbBackupTest extends \PHPUnit_Framework_TestCase
      * @covers ::setChecksum
      * @expectedException \InvalidArgumentException
      */
-    public function testSetChecksumWillThrowExceptionIfEmptyString()
+    public function testSetChecksumWillThrowExceptionIfNull()
     {
         $dbBackup = new DbBackup(12345678);
-        $dbBackup->setChecksum('');
+        $dbBackup->setChecksum(null);
     }
 }


### PR DESCRIPTION
Includes various changes to support database backups that are in a started/incomplete state:
- Path property of DbBackup can be null.
- Completed property of DbBackup can be 0.
- CheckSum property of DbBackup can be an empty string.
- Updates unit tests.
