### PR TITLE
TAC-4669 | Application accepts empty UUID string.

### DIFF
--- a/src/Hosting/Application.php
+++ b/src/Hosting/Application.php
@@ -169,12 +169,12 @@ final class Application implements ApplicationInterface
      */
     public function setUUID($uuid)
     {
-        if (!is_string($uuid) || empty($uuid)) {
+        if (!is_string($uuid)) {
             throw new \InvalidArgumentException(
                 sprintf('%s: $uuid expects a string.', __METHOD__)
             );
         }
-        $this->uuid = $uuid;
+        $this->uuid = empty($uuid) ? null : $uuid;
     }
 
     /**

--- a/tests/Hosting/ApplicationTest.php
+++ b/tests/Hosting/ApplicationTest.php
@@ -351,12 +351,13 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers ::setUUID
-     * @expectedException \InvalidArgumentException
+     * @expectedException \RuntimeException
      */
-    public function testSetUUIDWillThrowExceptionIfEmptyString()
+    public function testSetUUIDWillSetNullIfEmptyString()
     {
         $application = new Application('test');
         $application->setUUID('');
+        $application->getUUID();
     }
 
     /**


### PR DESCRIPTION
If an empty value is given as UUID it is set as null.