### PR TITLE
ENT-2801 | Update coveralls support.

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,3 @@
 # for php-coveralls
 service_name: travis-ci
-src_dir: src
 coverage_clover: build/logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - vendor/bin/phpmd src text cleancode,codesize,controversial,design,naming,unusedcode
 
 after_script:
-  - php vendor/bin/coveralls
+  - travis_retry php vendor/bin/php-coveralls

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "phpmd/phpmd": "@stable",
         "phpunit/phpunit": "~4.4",
-        "satooshi/php-coveralls": "*",
+        "satooshi/php-coveralls": "1.0.1",
         "squizlabs/php_codesniffer": "*",
         "symfony/yaml": " ~3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "phpmd/phpmd": "@stable",
         "phpunit/phpunit": "~4.4",
-        "satooshi/php-coveralls": "1.0.1",
+        "satooshi/php-coveralls": "~2.0",
         "squizlabs/php_codesniffer": "*",
         "symfony/yaml": " ~3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "phpmd/phpmd": "@stable",
         "phpunit/phpunit": "~4.4",
-        "satooshi/php-coveralls": "~2.0",
+        "php-coveralls/php-coveralls": "~2.0",
         "squizlabs/php_codesniffer": "*",
         "symfony/yaml": " ~3.0"
     },


### PR DESCRIPTION
- Removed an outdated coveralls config option related to php-coveralls < 0.8.0
- Updated the php-coveralls vendor name which changed last year
- Require ~2.0

Tested locally with php 5.6 and 7.1