### PR TITLE
 ENT-2802 | Update phpunit to for compatibility with php 7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - "5.6"
   - "7.0"
+  - "7.1"
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "phpmd/phpmd": "@stable",
-        "phpunit/phpunit": "~4.4",
+        "phpunit/phpunit": "~5.7",
         "php-coveralls/php-coveralls": "~2.0",
         "squizlabs/php_codesniffer": "*",
         "symfony/yaml": " ~3.0"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "phpmd/phpmd": "@stable",
-        "phpunit/phpunit": "~5.7|~7.1",
+        "phpunit/phpunit": "~5.7|~6.5|~7.1",
         "php-coveralls/php-coveralls": "~2.0",
         "squizlabs/php_codesniffer": "*",
         "symfony/yaml": " ~3.0"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "phpmd/phpmd": "@stable",
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "~5.7|~7.1",
         "php-coveralls/php-coveralls": "~2.0",
         "squizlabs/php_codesniffer": "*",
         "symfony/yaml": " ~3.0"

--- a/tests/Common/Traits/ArrayObjectImplementationMethodsTest.php
+++ b/tests/Common/Traits/ArrayObjectImplementationMethodsTest.php
@@ -11,10 +11,12 @@
 
 namespace Acquia\Platform\Cloud\Tests\Common\Traits;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @coversDefaultClass Acquia\Platform\Cloud\Common\Traits\ArrayObjectImplementationMethods
  */
-class ArrayObjectImplementationMethodsTest extends \PHPUnit_Framework_TestCase
+class ArrayObjectImplementationMethodsTest extends TestCase
 {
     const TEST_TRAIT = 'Acquia\Platform\Cloud\Common\Traits\ArrayObjectImplementationMethods';
     const TEST_ITERATOR = 'Acquia\Platform\Cloud\Tests\Fixtures\MockArrayIterator';

--- a/tests/Hosting/Application/ApplicationDecoratorMethodsTest.php
+++ b/tests/Hosting/Application/ApplicationDecoratorMethodsTest.php
@@ -16,11 +16,12 @@ use Acquia\Platform\Cloud\Hosting\ApplicationInterface;
 use Acquia\Platform\Cloud\Hosting\Environment;
 use Acquia\Platform\Cloud\Hosting\Environment\EnvironmentList;
 use Acquia\Platform\Cloud\Hosting\Realm;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Application\ApplicationDecoratorMethods
  */
-class ApplicationDecoratorMethodsTest extends \PHPUnit_Framework_TestCase
+class ApplicationDecoratorMethodsTest extends TestCase
 {
     const TEST_TRAIT = 'Acquia\Platform\Cloud\Hosting\Application\ApplicationDecoratorMethods';
     const TEST_APP = 'Acquia\Platform\Cloud\Hosting\ApplicationInterface';

--- a/tests/Hosting/Application/ApplicationListTest.php
+++ b/tests/Hosting/Application/ApplicationListTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\Application;
 
 use Acquia\Platform\Cloud\Hosting\Application;
 use Acquia\Platform\Cloud\Hosting\Application\ApplicationList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass Acquia\Platform\Cloud\Hosting\Application\ApplicationList
  */
-class ApplicationListTest extends \PHPUnit_Framework_TestCase
+class ApplicationListTest extends TestCase
 {
     private $childrenOfHyperion = ['Helios', 'Selene', 'Eos'];
     private $childrenOfCoeus = ['Lelantos', 'Leto', 'Asteria'];

--- a/tests/Hosting/ApplicationTest.php
+++ b/tests/Hosting/ApplicationTest.php
@@ -15,11 +15,12 @@ use Acquia\Platform\Cloud\Hosting\Application;
 use Acquia\Platform\Cloud\Hosting\Environment;
 use Acquia\Platform\Cloud\Hosting\Environment\EnvironmentList;
 use Acquia\Platform\Cloud\Hosting\Realm;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Application
  */
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends TestCase
 {
     /**
      * @covers ::__construct

--- a/tests/Hosting/DbBackup/DbBackupDecoratorMethodsTest.php
+++ b/tests/Hosting/DbBackup/DbBackupDecoratorMethodsTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\DbBackup;
 
 use Acquia\Platform\Cloud\Hosting\DbBackup\DbBackupDecoratorMethods;
 use Acquia\Platform\Cloud\Hosting\DbBackupInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\DbBackup\DbBackupDecoratorMethods
  */
-class DbBackupDecoratorMethodsTest extends \PHPUnit_Framework_TestCase
+class DbBackupDecoratorMethodsTest extends TestCase
 {
     const TEST_TRAIT = 'Acquia\Platform\Cloud\Hosting\DbBackup\DbBackupDecoratorMethods';
     const TEST_CLASS = 'Acquia\Platform\Cloud\Hosting\DbBackupInterface';

--- a/tests/Hosting/DbBackup/DbBackupListTest.php
+++ b/tests/Hosting/DbBackup/DbBackupListTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\DbBackup;
 
 use Acquia\Platform\Cloud\Hosting\DbBackup;
 use Acquia\Platform\Cloud\Hosting\DbBackup\DbBackupList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass Acquia\Platform\Cloud\Hosting\DbBackup\DbBackupList
  */
-class DbBackupListTest extends \PHPUnit_Framework_TestCase
+class DbBackupListTest extends TestCase
 {
     private $primesUnderTen = [2, 3, 5, 7];
     private $primesUnderTwenty = [11, 13, 17, 19];

--- a/tests/Hosting/DbBackupTest.php
+++ b/tests/Hosting/DbBackupTest.php
@@ -12,11 +12,12 @@
 namespace Acquia\Platform\Cloud\Tests\Hosting;
 
 use Acquia\Platform\Cloud\Hosting\DbBackup;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\DbBackup
  */
-class DbBackupTest extends \PHPUnit_Framework_TestCase
+class DbBackupTest extends TestCase
 {
     /**
      * @covers ::__construct

--- a/tests/Hosting/DbInstance/DbInstanceDecoratorMethodsTest.php
+++ b/tests/Hosting/DbInstance/DbInstanceDecoratorMethodsTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\DbInstance;
 
 use Acquia\Platform\Cloud\Hosting\DbInstance\DbInstanceDecoratorMethods;
 use Acquia\Platform\Cloud\Hosting\DbInstanceInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\DbInstance\DbInstanceDecoratorMethods
  */
-class DbInstanceDecoratorMethodsTest extends \PHPUnit_Framework_TestCase
+class DbInstanceDecoratorMethodsTest extends TestCase
 {
     const TEST_TRAIT = 'Acquia\Platform\Cloud\Hosting\DbInstance\DbInstanceDecoratorMethods';
     const TEST_CLASS = 'Acquia\Platform\Cloud\Hosting\DbInstanceInterface';

--- a/tests/Hosting/DbInstance/DbInstanceListTest.php
+++ b/tests/Hosting/DbInstance/DbInstanceListTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\DbInstance;
 
 use Acquia\Platform\Cloud\Hosting\DbInstance;
 use Acquia\Platform\Cloud\Hosting\DbInstance\DbInstanceList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass Acquia\Platform\Cloud\Hosting\DbInstance\DbInstanceList
  */
-class DbInstanceListTest extends \PHPUnit_Framework_TestCase
+class DbInstanceListTest extends TestCase
 {
     private $childrenOfHyperion = ['Helios', 'Selene', 'Eos'];
     private $childrenOfCoeus = ['Lelantos', 'Leto', 'Asteria'];

--- a/tests/Hosting/DbInstanceTest.php
+++ b/tests/Hosting/DbInstanceTest.php
@@ -12,11 +12,12 @@
 namespace Acquia\Platform\Cloud\Tests\Hosting;
 
 use Acquia\Platform\Cloud\Hosting\DbInstance;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\DbInstance
  */
-class DbInstanceTest extends \PHPUnit_Framework_TestCase
+class DbInstanceTest extends TestCase
 {
     /**
      * Data provider of valid instance names.

--- a/tests/Hosting/Environment/EnvironmentDecoratorMethodsTest.php
+++ b/tests/Hosting/Environment/EnvironmentDecoratorMethodsTest.php
@@ -14,11 +14,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\Environment;
 use Acquia\Platform\Cloud\Hosting\Environment\EnvironmentDecoratorMethods;
 use Acquia\Platform\Cloud\Hosting\EnvironmentInterface;
 use Acquia\Platform\Cloud\Hosting\Realm;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Environment\EnvironmentDecoratorMethods
  */
-class EnvironmentDecoratorMethodsTest extends \PHPUnit_Framework_TestCase
+class EnvironmentDecoratorMethodsTest extends TestCase
 {
     const TEST_TRAIT = 'Acquia\Platform\Cloud\Hosting\Environment\EnvironmentDecoratorMethods';
     const TEST_APP = 'Acquia\Platform\Cloud\Hosting\EnvironmentInterface';

--- a/tests/Hosting/Environment/EnvironmentListTest.php
+++ b/tests/Hosting/Environment/EnvironmentListTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\Environment;
 
 use Acquia\Platform\Cloud\Hosting\Environment;
 use Acquia\Platform\Cloud\Hosting\Environment\EnvironmentList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass Acquia\Platform\Cloud\Hosting\Environment\EnvironmentList
  */
-class EnvironmentListTest extends \PHPUnit_Framework_TestCase
+class EnvironmentListTest extends TestCase
 {
     private $childrenOfLeto = ['Apollo','Artemis'];
     private $childrenOfAtlas = ['Hesperides', 'Hyades', 'Hyas', 'Pleiades', 'Calypso', 'Dione', 'Maera'];

--- a/tests/Hosting/EnvironmentTest.php
+++ b/tests/Hosting/EnvironmentTest.php
@@ -14,11 +14,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting;
 use Acquia\Platform\Cloud\Hosting\Environment;
 use Acquia\Platform\Cloud\Hosting\Server;
 use Acquia\Platform\Cloud\Hosting\Server\ServerList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Environment
  */
-class EnvironmentTest extends \PHPUnit_Framework_TestCase
+class EnvironmentTest extends TestCase
 {
     /**
      * @covers ::__construct()

--- a/tests/Hosting/Monitor/MonitorListTest.php
+++ b/tests/Hosting/Monitor/MonitorListTest.php
@@ -21,7 +21,7 @@ class MonitorListTest extends \PHPUnit_Framework_TestCase
 {
     protected function getMonitor($serviceName = 'service')
     {
-        $mock = $this->getMock('Acquia\Platform\Cloud\Hosting\Monitor\MonitorInterface');
+        $mock = $this->getMockBuilder(MonitorInterface::class)->getMock();
         $mock->expects($this->any())
             ->method('getMonitoringUrls')
             ->willReturn(['url'])
@@ -49,7 +49,7 @@ class MonitorListTest extends \PHPUnit_Framework_TestCase
     public function testAllowsMonitorToBeAppended()
     {
         $list = new MonitorList();
-        $list->append($this->getMock('Acquia\Platform\Cloud\Hosting\Monitor\MonitorInterface'));
+        $list->append($this->getMockBuilder(MonitorInterface::class)->getMock());
         $this->assertTrue($list[0] instanceof MonitorInterface);
     }
 

--- a/tests/Hosting/Monitor/MonitorListTest.php
+++ b/tests/Hosting/Monitor/MonitorListTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\Monitor;
 
 use Acquia\Platform\Cloud\Hosting\Monitor\MonitorInterface;
 use Acquia\Platform\Cloud\Hosting\Monitor\MonitorList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Monitor\MonitorList
  */
-class MonitorListTest extends \PHPUnit_Framework_TestCase
+class MonitorListTest extends TestCase
 {
     protected function getMonitor($serviceName = 'service')
     {

--- a/tests/Hosting/Monitor/MonitorableTest.php
+++ b/tests/Hosting/Monitor/MonitorableTest.php
@@ -11,6 +11,7 @@
 
 namespace Acquia\Platform\Cloud\Tests\Hosting\Monitor;
 
+use Acquia\Platform\Cloud\Hosting\Monitor\MonitorInterface;
 use Acquia\Platform\Cloud\Hosting\Monitor\MonitorList;
 
 /**
@@ -25,7 +26,7 @@ class MonitorableTest extends \PHPUnit_Framework_TestCase
 
     protected function getMonitor($serviceName = 'service')
     {
-        $mock = $this->getMock('Acquia\Platform\Cloud\Hosting\Monitor\MonitorInterface');
+        $mock = $this->getMockBuilder(MonitorInterface::class)->getMock();
         $mock->expects($this->any())
             ->method('getMonitoringUrls')
             ->willReturn(['url'])

--- a/tests/Hosting/Monitor/MonitorableTest.php
+++ b/tests/Hosting/Monitor/MonitorableTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\Monitor;
 
 use Acquia\Platform\Cloud\Hosting\Monitor\MonitorInterface;
 use Acquia\Platform\Cloud\Hosting\Monitor\MonitorList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Monitor\Monitorable
  */
-class MonitorableTest extends \PHPUnit_Framework_TestCase
+class MonitorableTest extends TestCase
 {
     protected function getMonitorable()
     {

--- a/tests/Hosting/Realm/RealmDecoratorMethodsTest.php
+++ b/tests/Hosting/Realm/RealmDecoratorMethodsTest.php
@@ -14,11 +14,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\Realm;
 use Acquia\Platform\Cloud\Hosting\Realm\RealmDecoratorMethods;
 use Acquia\Platform\Cloud\Hosting\RealmInterface;
 use Acquia\Platform\Cloud\Hosting\Realm;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Realm\RealmDecoratorMethods
  */
-class RealmDecoratorMethodsTest extends \PHPUnit_Framework_TestCase
+class RealmDecoratorMethodsTest extends TestCase
 {
     const TEST_TRAIT = 'Acquia\Platform\Cloud\Hosting\Realm\RealmDecoratorMethods';
     const TEST_APP = 'Acquia\Platform\Cloud\Hosting\RealmInterface';

--- a/tests/Hosting/Realm/RealmListTest.php
+++ b/tests/Hosting/Realm/RealmListTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\Realm;
 
 use Acquia\Platform\Cloud\Hosting\Realm;
 use Acquia\Platform\Cloud\Hosting\Realm\RealmList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass Acquia\Platform\Cloud\Hosting\Realm\RealmList
  */
-class RealmListTest extends \PHPUnit_Framework_TestCase
+class RealmListTest extends TestCase
 {
     private $daughtersOfGaia = ['Mnemosyne',  'Tethys', 'Theia', 'Phoebe', 'Rhea', 'Themis'];
     private $sonsOfUranus = ['Oceanus', 'Hyperion', 'Coeus', 'Cronus', 'Crius', 'Iapetus'];

--- a/tests/Hosting/RealmTest.php
+++ b/tests/Hosting/RealmTest.php
@@ -12,11 +12,12 @@
 namespace Acquia\Platform\Cloud\Tests\Hosting;
 
 use Acquia\Platform\Cloud\Hosting\Realm;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Realm
  */
-class RealmTest extends \PHPUnit_Framework_TestCase
+class RealmTest extends TestCase
 {
     /**
      * @covers ::__construct()

--- a/tests/Hosting/Server/BalancerServerListTest.php
+++ b/tests/Hosting/Server/BalancerServerListTest.php
@@ -15,11 +15,12 @@ use Acquia\Platform\Cloud\Hosting\Server;
 use Acquia\Platform\Cloud\Hosting\Server\BalancerServerList;
 use Acquia\Platform\Cloud\Hosting\Server\BalancerServerListInterface;
 use Acquia\Platform\Cloud\Hosting\ServerInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Server\BalancerServerList
  */
-class BalancerServerListTest extends \PHPUnit_Framework_TestCase
+class BalancerServerListTest extends TestCase
 {
     /**
      * @covers ::getActiveBalancers

--- a/tests/Hosting/Server/ServerDecoratorMethodsTest.php
+++ b/tests/Hosting/Server/ServerDecoratorMethodsTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\Server;
 
 use Acquia\Platform\Cloud\Hosting\Server\ServerDecoratorMethods;
 use Acquia\Platform\Cloud\Hosting\ServerInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Server\ServerDecoratorMethods
  */
-class ServerDecoratorMethodsTest extends \PHPUnit_Framework_TestCase
+class ServerDecoratorMethodsTest extends TestCase
 {
     const TEST_TRAIT = 'Acquia\Platform\Cloud\Hosting\Server\ServerDecoratorMethods';
     const TEST_CLASS = 'Acquia\Platform\Cloud\Hosting\ServerInterface';

--- a/tests/Hosting/Server/ServerListTest.php
+++ b/tests/Hosting/Server/ServerListTest.php
@@ -18,11 +18,12 @@ use Acquia\Platform\Cloud\Hosting\Server\DatabaseServerListInterface;
 use Acquia\Platform\Cloud\Hosting\Server\FileServerListInterface;
 use Acquia\Platform\Cloud\Hosting\Server\VcsServerListInterface;
 use Acquia\Platform\Cloud\Hosting\Server\WebServerListInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass Acquia\Platform\Cloud\Hosting\Server\ServerList
  */
-class ServerListTest extends \PHPUnit_Framework_TestCase
+class ServerListTest extends TestCase
 {
     private $childrenOfHyperion = ['Helios-10', 'Selene-20', 'Eos-30'];
     private $childrenOfCoeus = ['Lelantos-100', 'Leto-110', 'Asteria-120'];

--- a/tests/Hosting/ServerTest.php
+++ b/tests/Hosting/ServerTest.php
@@ -12,11 +12,12 @@
 namespace Acquia\Platform\Cloud\Tests\Hosting;
 
 use Acquia\Platform\Cloud\Hosting\Server;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Server
  */
-class ServerTest extends \PHPUnit_Framework_TestCase
+class ServerTest extends TestCase
 {
     /**
      * @covers ::__construct

--- a/tests/Hosting/Task/TaskDecoratorMethodsTest.php
+++ b/tests/Hosting/Task/TaskDecoratorMethodsTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\Task;
 
 use Acquia\Platform\Cloud\Hosting\Task\TaskDecoratorMethods;
 use Acquia\Platform\Cloud\Hosting\TaskInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Task\TaskDecoratorMethods
  */
-class TaskDecoratorMethodsTest extends \PHPUnit_Framework_TestCase
+class TaskDecoratorMethodsTest extends TestCase
 {
     const TEST_TRAIT = 'Acquia\Platform\Cloud\Hosting\Task\TaskDecoratorMethods';
     const TEST_CLASS = 'Acquia\Platform\Cloud\Hosting\TaskInterface';

--- a/tests/Hosting/Task/TaskListTest.php
+++ b/tests/Hosting/Task/TaskListTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\Task;
 
 use Acquia\Platform\Cloud\Hosting\Task;
 use Acquia\Platform\Cloud\Hosting\Task\TaskList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass Acquia\Platform\Cloud\Hosting\Task\TaskList
  */
-class TaskListTest extends \PHPUnit_Framework_TestCase
+class TaskListTest extends TestCase
 {
     private $idsOfHyperion = [123, 345, 567];
     private $idsOfCoeus = [890, 980, 827];

--- a/tests/Hosting/TaskTest.php
+++ b/tests/Hosting/TaskTest.php
@@ -12,11 +12,12 @@
 namespace Acquia\Platform\Cloud\Tests\Hosting;
 
 use Acquia\Platform\Cloud\Hosting\Task;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\Task
  */
-class TaskTest extends \PHPUnit_Framework_TestCase
+class TaskTest extends TestCase
 {
     /**
      * @covers ::__construct

--- a/tests/Hosting/VersionControl/GitRepositoryTest.php
+++ b/tests/Hosting/VersionControl/GitRepositoryTest.php
@@ -14,11 +14,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\VersionControl;
 use Acquia\Platform\Cloud\Hosting\Application;
 use Acquia\Platform\Cloud\Hosting\Environment;
 use Acquia\Platform\Cloud\Hosting\VersionControl\GitRepository;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\VersionControl\GitRepository
  */
-class GitRepositoryTest extends \PHPUnit_Framework_TestCase
+class GitRepositoryTest extends TestCase
 {
     const GIT_REPO_URL = 'sample@vcs-123.test:sample.git';
     const GIT_REPO_BRANCH = 'testbranch';

--- a/tests/Hosting/VersionControl/RepositoryFactoryTest.php
+++ b/tests/Hosting/VersionControl/RepositoryFactoryTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\VersionControl;
 
 use Acquia\Platform\Cloud\Hosting\Application;
 use Acquia\Platform\Cloud\Hosting\VersionControl\RepositoryFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\VersionControl\RepositoryFactory
  */
-class RepositoryFactoryTest extends \PHPUnit_Framework_TestCase
+class RepositoryFactoryTest extends TestCase
 {
     /**
      * @covers ::getRepository

--- a/tests/Hosting/VersionControl/RepositoryTest.php
+++ b/tests/Hosting/VersionControl/RepositoryTest.php
@@ -13,11 +13,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\VersionControl;
 
 use Acquia\Platform\Cloud\Hosting\Application;
 use Acquia\Platform\Cloud\Hosting\Environment;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\VersionControl\Repository
  */
-class RepositoryTest extends \PHPUnit_Framework_TestCase
+class RepositoryTest extends TestCase
 {
     protected function getConcreteRepository()
     {

--- a/tests/Hosting/VersionControl/SubversionRepositoryTest.php
+++ b/tests/Hosting/VersionControl/SubversionRepositoryTest.php
@@ -14,11 +14,12 @@ namespace Acquia\Platform\Cloud\Tests\Hosting\VersionControl;
 use Acquia\Platform\Cloud\Hosting\Application;
 use Acquia\Platform\Cloud\Hosting\Environment;
 use Acquia\Platform\Cloud\Hosting\VersionControl\SubversionRepository;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Acquia\Platform\Cloud\Hosting\VersionControl\SubversionRepository
  */
-class SubversionRepositoryTest extends \PHPUnit_Framework_TestCase
+class SubversionRepositoryTest extends TestCase
 {
     const SVN_REPO_URL = 'https://svn-123.test/sample';
     const SVN_REPO_BRANCH = 'testbranch';


### PR DESCRIPTION
- Updates few deprecated calls to `getMock(..)`
- Switch to phpunit's newer namespacing method for `TestCase`
- Require either phpunit ~5.7 (for php 5.6+),~6.5 (php 7.0+), or ~7.1 (php 7.1+)
- Add php 7.1 to travis matrix.

NOTE: this PR will have a merge conflict with #44, and need to be rebased after that one is merged