### PR TITLE
ENT-6468 | acquia-platform-cloud-data-model should run tests under modern PHP versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - "5.6"
-  - "7.0"
   - "7.1"
+  - "7.2"
+  - "7.3"
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,16 @@
             "homepage": "https://github.com/webbj74/acquia-platform-cloud-data-model/graphs/contributors"
         }
     ],
+    "config": {
+        "sort-packages": true
+    },
     "require": {
-        "php": ">=5.5.9"
+        "php": "^7.1"
     },
     "require-dev": {
-        "phpmd/phpmd": "@stable",
-        "phpunit/phpunit": "~5.7|~6.5|~7.1",
         "php-coveralls/php-coveralls": "~2.0",
+        "phpmd/phpmd": "@stable",
+        "phpunit/phpunit": "^7.5|^8.0",
         "squizlabs/php_codesniffer": "*",
         "symfony/yaml": "~3.0|~4.0"
     },


### PR DESCRIPTION
* Removes PHP 5.6 and 7.0 from Travis tests; adds PHP 7.2 and 7.3.
* Updates PHPUnit version support in Composer.