### PR TITLE
Update getRevision() and setRevision() to allow for the possibility that $revision may contain an empty string.

### DIFF
--- a/src/Hosting/Environment.php
+++ b/src/Hosting/Environment.php
@@ -100,7 +100,7 @@ final class Environment implements EnvironmentInterface
      */
     public function getRevision()
     {
-        if ($this->revision === null) {
+        if (empty($this->revision)) {
             throw new RuntimeException(
                 sprintf('%s: This Environment object does not know its VCS revision.', __METHOD__)
             );
@@ -113,7 +113,7 @@ final class Environment implements EnvironmentInterface
      */
     public function setRevision($revision)
     {
-        if (!is_string($revision) || empty($revision)) {
+        if (!is_string($revision)) {
             throw new InvalidArgumentException(
                 sprintf('%s: $revision expects a string.', __METHOD__)
             );

--- a/src/Hosting/Environment.php
+++ b/src/Hosting/Environment.php
@@ -100,7 +100,7 @@ final class Environment implements EnvironmentInterface
      */
     public function getRevision()
     {
-        if (empty($this->revision)) {
+        if ($this->revision === null) {
             throw new RuntimeException(
                 sprintf('%s: This Environment object does not know its VCS revision.', __METHOD__)
             );

--- a/src/Hosting/Server/ServerList.php
+++ b/src/Hosting/Server/ServerList.php
@@ -94,6 +94,11 @@ class ServerList extends ArrayObject implements ServerListInterface
 
     /**
      * {@inheritdoc}
+     *
+     * PHPMD is incorrectly flagging $matches as an undefined variable.
+     * @see https://github.com/phpmd/phpmd/issues/672
+     *
+     * @SuppressWarnings(PHPMD.UndefinedVariable)
      */
     public function getLowestNumberedServer()
     {

--- a/tests/Hosting/EnvironmentTest.php
+++ b/tests/Hosting/EnvironmentTest.php
@@ -106,9 +106,9 @@ class EnvironmentTest extends TestCase
 
     /**
      * @covers ::setRevision
-     * @dataProvider nonStringProvider()
+     * @dataProvider nullDataProvider()
      */
-    public function testRevisionPropertyRejectsNonString($value)
+    public function testRevisionPropertyRejectsNullValue($value)
     {
         $this->expectException(InvalidArgumentException::class);
         $environment = new Environment('test');
@@ -417,6 +417,13 @@ class EnvironmentTest extends TestCase
     {
         return [
             'empty string' => [''],
+            'NULL' => [null],
+        ];
+    }
+
+    public function nullDataProvider()
+    {
+        return [
             'NULL' => [null],
         ];
     }


### PR DESCRIPTION
This is a simple PR to allow for the possibility that `vcs_revision` may contain an empty string.